### PR TITLE
Errors in templates now show line of error and surrounding context, command errors show the command that failed and all preceding commands, the two most common usage errors.

### DIFF
--- a/.zetch.lock
+++ b/.zetch.lock
@@ -1,16 +1,16 @@
 {
   "version": "0.0.10",
   "files": {
+    "setup.zetch.cfg": "ec37422c63513f42feab279eaad528e834dd4480cd9c3e2789b2fd9bea626ed1",
     "README.zetch.md": "bf36c066d493db3c44a95ef89989ce310c8905df162d772db21913cc7a113311",
-    "LICENSE.zetch.md": "d2c12e539d357957b950a54a5477c3a9f87bd2b3ee707be7a4db7adaf5aacc2b",
-    "py_rust/README.zetch.md": "2eda002221d0f22c813a6de54c44a78fc029f516f023c8f7b52bdd437f22c54f",
-    "CONTRIBUTING.zetch.md": "c1163c54e695dc64174c047f48976e927b6aae4f6fbf4c94ebd06ef56f8ba02f",
     "docs/CODE_OF_CONDUCT.zetch.md": "bf106326ffc75f5167cfde27c997c77c6b97c843a9e392b564355d0e70e50b97",
+    "docs/CONTRIBUTING.zetch.md": "c1163c54e695dc64174c047f48976e927b6aae4f6fbf4c94ebd06ef56f8ba02f",
+    "CONTRIBUTING.zetch.md": "c1163c54e695dc64174c047f48976e927b6aae4f6fbf4c94ebd06ef56f8ba02f",
     "docs/index.zetch.md": "2eda002221d0f22c813a6de54c44a78fc029f516f023c8f7b52bdd437f22c54f",
     "docs/LICENSE.zetch.md": "d2c12e539d357957b950a54a5477c3a9f87bd2b3ee707be7a4db7adaf5aacc2b",
-    "py_rust/LICENSE.zetch.md": "d2c12e539d357957b950a54a5477c3a9f87bd2b3ee707be7a4db7adaf5aacc2b",
     "CODE_OF_CONDUCT.zetch.md": "bf106326ffc75f5167cfde27c997c77c6b97c843a9e392b564355d0e70e50b97",
-    "setup.zetch.cfg": "ec37422c63513f42feab279eaad528e834dd4480cd9c3e2789b2fd9bea626ed1",
-    "docs/CONTRIBUTING.zetch.md": "c1163c54e695dc64174c047f48976e927b6aae4f6fbf4c94ebd06ef56f8ba02f"
+    "py_rust/README.zetch.md": "2eda002221d0f22c813a6de54c44a78fc029f516f023c8f7b52bdd437f22c54f",
+    "py_rust/LICENSE.zetch.md": "d2c12e539d357957b950a54a5477c3a9f87bd2b3ee707be7a4db7adaf5aacc2b",
+    "LICENSE.zetch.md": "d2c12e539d357957b950a54a5477c3a9f87bd2b3ee707be7a4db7adaf5aacc2b"
   }
 }

--- a/py_rust/Cargo.lock
+++ b/py_rust/Cargo.lock
@@ -170,9 +170,9 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitbazaar"
-version = "0.0.37"
+version = "0.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc0a291d22dba1e87dbdb03aee9268364a970f455258f22253cbc27854e82f2"
+checksum = "639f2d11715601ccc0ba383a11209d87f89361736242b3ebf0182c7299a3d682"
 dependencies = [
  "chrono",
  "clap",

--- a/py_rust/Cargo.toml
+++ b/py_rust/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/lib.rs"
 colored = '2'
 tracing = "0.1"
 error-stack = "0.4"
-bitbazaar = { version = '0.0.37', features = ["cli", "timing", "clap"] }
+bitbazaar = { version = "0.0.38", features = ["cli", "timing", "clap"] }
 pyo3 = { version = '0.20.0', features = ['extension-module', 'chrono', 'generate-import-lib'] }
 parking_lot = { version = "0.12", features = ['deadlock_detection', 'serde'] }
 strum = { version = '0.25', features = ['derive'] }

--- a/py_rust/src/config/load.rs
+++ b/py_rust/src/config/load.rs
@@ -172,10 +172,11 @@ pub fn load(
                 let config_dir_clone = config_dir.clone();
                 handles.push(std::thread::spawn(
                     move || -> Result<(String, serde_json::Value), Zerr> {
-                        let value = value
-                            .consume(&config_dir_clone)
-                            .change_context(Zerr::ContextLoadError)
-                            .attach_printable_lazy(|| format!("Ctx cli var: '{key}'"))?;
+                        let value = timeit!(format!("Cli var processing: '{}'", &key).as_str(), {
+                            value.consume(&config_dir_clone)
+                        })
+                        .change_context(Zerr::ContextLoadError)
+                        .attach_printable_lazy(|| format!("Ctx cli var: '{key}'"))?;
                         Ok((key, value))
                     },
                 ));

--- a/py_rust/src/config/tasks.rs
+++ b/py_rust/src/config/tasks.rs
@@ -71,15 +71,7 @@ impl Task {
                 _ => Err(e.change_context(Zerr::UserCommandError)),
             },
         }?;
-
-        if cmd_out.code != 0 {
-            return Err(zerr!(
-                Zerr::UserCommandError,
-                "Returned non zero exit code: {}. Std output: {}",
-                cmd_out.code,
-                cmd_out.std_all()
-            ));
-        }
+        cmd_out.throw_on_bad_code(Zerr::UserCommandError)?;
 
         Ok(())
     }

--- a/py_rust/tests/render/test_engine.py
+++ b/py_rust/tests/render/test_engine.py
@@ -164,7 +164,7 @@ def test_engine_config(template_src: str, engine_config: Engine, expected: str):
         (
             "Hello, {{ var }}! My name is {{ name }}!",
             {"context": {"static": {"var": {"value": "World"}}}},
-            "Failed to render template: 'undefined value",
+            "undefined value",
             True,
         ),
     ],

--- a/py_rust/tests/test_config_invalid.py
+++ b/py_rust/tests/test_config_invalid.py
@@ -294,7 +294,7 @@ def test_failing_cli_errs():
 
     # Should error when script returns nothing (implicit None)
     with TmpFileManager() as manager:
-        with pytest.raises(ValueError, match="Implicit None. Final cli script returned nothing."):
+        with pytest.raises(ValueError, match="Implicit None. Final cli command returned nothing."):
             tmpfile = manager.tmpfile("", suffix=".txt")
             cli.render(
                 manager.root_dir,


### PR DESCRIPTION
 command errors should the command that failed and all preceding commands, the two most common usage errors,