### PR TITLE
Error msgs improved, cli light vals and enf defaults use static syntax, to allow coersion

### DIFF
--- a/.zetch.lock
+++ b/.zetch.lock
@@ -1,16 +1,16 @@
 {
   "version": "0.0.10",
   "files": {
+    "docs/LICENSE.zetch.md": "d2c12e539d357957b950a54a5477c3a9f87bd2b3ee707be7a4db7adaf5aacc2b",
     "docs/index.zetch.md": "2eda002221d0f22c813a6de54c44a78fc029f516f023c8f7b52bdd437f22c54f",
+    "setup.zetch.cfg": "15bce71e401fb412ff2a42a2195000e4cefb378c2a3d0b984cb06844cd04b4bf",
+    "docs/CONTRIBUTING.zetch.md": "c1163c54e695dc64174c047f48976e927b6aae4f6fbf4c94ebd06ef56f8ba02f",
+    "LICENSE.zetch.md": "d2c12e539d357957b950a54a5477c3a9f87bd2b3ee707be7a4db7adaf5aacc2b",
+    "docs/CODE_OF_CONDUCT.zetch.md": "bf106326ffc75f5167cfde27c997c77c6b97c843a9e392b564355d0e70e50b97",
+    "py_rust/LICENSE.zetch.md": "d2c12e539d357957b950a54a5477c3a9f87bd2b3ee707be7a4db7adaf5aacc2b",
+    "CODE_OF_CONDUCT.zetch.md": "bf106326ffc75f5167cfde27c997c77c6b97c843a9e392b564355d0e70e50b97",
     "py_rust/README.zetch.md": "2eda002221d0f22c813a6de54c44a78fc029f516f023c8f7b52bdd437f22c54f",
     "CONTRIBUTING.zetch.md": "c1163c54e695dc64174c047f48976e927b6aae4f6fbf4c94ebd06ef56f8ba02f",
-    "CODE_OF_CONDUCT.zetch.md": "bf106326ffc75f5167cfde27c997c77c6b97c843a9e392b564355d0e70e50b97",
-    "LICENSE.zetch.md": "d2c12e539d357957b950a54a5477c3a9f87bd2b3ee707be7a4db7adaf5aacc2b",
-    "setup.zetch.cfg": "15bce71e401fb412ff2a42a2195000e4cefb378c2a3d0b984cb06844cd04b4bf",
-    "docs/LICENSE.zetch.md": "d2c12e539d357957b950a54a5477c3a9f87bd2b3ee707be7a4db7adaf5aacc2b",
-    "README.zetch.md": "bf36c066d493db3c44a95ef89989ce310c8905df162d772db21913cc7a113311",
-    "docs/CONTRIBUTING.zetch.md": "c1163c54e695dc64174c047f48976e927b6aae4f6fbf4c94ebd06ef56f8ba02f",
-    "py_rust/LICENSE.zetch.md": "d2c12e539d357957b950a54a5477c3a9f87bd2b3ee707be7a4db7adaf5aacc2b",
-    "docs/CODE_OF_CONDUCT.zetch.md": "bf106326ffc75f5167cfde27c997c77c6b97c843a9e392b564355d0e70e50b97"
+    "README.zetch.md": "bf36c066d493db3c44a95ef89989ce310c8905df162d772db21913cc7a113311"
   }
 }

--- a/.zetch.lock
+++ b/.zetch.lock
@@ -1,16 +1,16 @@
 {
   "version": "0.0.10",
   "files": {
+    "CONTRIBUTING.zetch.md": "c1163c54e695dc64174c047f48976e927b6aae4f6fbf4c94ebd06ef56f8ba02f",
+    "py_rust/LICENSE.zetch.md": "d2c12e539d357957b950a54a5477c3a9f87bd2b3ee707be7a4db7adaf5aacc2b",
+    "CODE_OF_CONDUCT.zetch.md": "bf106326ffc75f5167cfde27c997c77c6b97c843a9e392b564355d0e70e50b97",
+    "py_rust/README.zetch.md": "2eda002221d0f22c813a6de54c44a78fc029f516f023c8f7b52bdd437f22c54f",
+    "README.zetch.md": "bf36c066d493db3c44a95ef89989ce310c8905df162d772db21913cc7a113311",
     "docs/LICENSE.zetch.md": "d2c12e539d357957b950a54a5477c3a9f87bd2b3ee707be7a4db7adaf5aacc2b",
     "docs/index.zetch.md": "2eda002221d0f22c813a6de54c44a78fc029f516f023c8f7b52bdd437f22c54f",
     "setup.zetch.cfg": "15bce71e401fb412ff2a42a2195000e4cefb378c2a3d0b984cb06844cd04b4bf",
     "docs/CONTRIBUTING.zetch.md": "c1163c54e695dc64174c047f48976e927b6aae4f6fbf4c94ebd06ef56f8ba02f",
     "LICENSE.zetch.md": "d2c12e539d357957b950a54a5477c3a9f87bd2b3ee707be7a4db7adaf5aacc2b",
-    "docs/CODE_OF_CONDUCT.zetch.md": "bf106326ffc75f5167cfde27c997c77c6b97c843a9e392b564355d0e70e50b97",
-    "py_rust/LICENSE.zetch.md": "d2c12e539d357957b950a54a5477c3a9f87bd2b3ee707be7a4db7adaf5aacc2b",
-    "CODE_OF_CONDUCT.zetch.md": "bf106326ffc75f5167cfde27c997c77c6b97c843a9e392b564355d0e70e50b97",
-    "py_rust/README.zetch.md": "2eda002221d0f22c813a6de54c44a78fc029f516f023c8f7b52bdd437f22c54f",
-    "CONTRIBUTING.zetch.md": "c1163c54e695dc64174c047f48976e927b6aae4f6fbf4c94ebd06ef56f8ba02f",
-    "README.zetch.md": "bf36c066d493db3c44a95ef89989ce310c8905df162d772db21913cc7a113311"
+    "docs/CODE_OF_CONDUCT.zetch.md": "bf106326ffc75f5167cfde27c997c77c6b97c843a9e392b564355d0e70e50b97"
   }
 }

--- a/py_rust/Cargo.toml
+++ b/py_rust/Cargo.toml
@@ -44,6 +44,7 @@ minijinja = { version = '1.0.10', features = [
   'preserve_order',
   'json',
   'urlencode',
+  'debug',
 ] }
 minijinja-contrib = { version = '1.0.10', features = ['datetime'] }
 

--- a/py_rust/src/config/context.rs
+++ b/py_rust/src/config/context.rs
@@ -23,7 +23,7 @@ impl CtxStaticVar {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct CtxEnvVar {
     pub env_name: Option<String>,
-    pub default: Option<serde_json::Value>,
+    pub default: Option<CtxStaticVar>,
     pub coerce: Option<Coerce>,
 }
 
@@ -45,7 +45,7 @@ impl CtxEnvVar {
                     ));
                 } else {
                     match &self.default {
-                        Some(value) => return Ok(value.clone()),
+                        Some(value) => return value.read(),
                         None => {
                             return Err(zerr!(
                                 Zerr::ContextLoadError,
@@ -66,7 +66,7 @@ impl CtxEnvVar {
 pub struct CtxCliVar {
     pub commands: Vec<String>,
     pub coerce: Option<Coerce>,
-    pub light: Option<serde_json::Value>,
+    pub light: Option<CtxStaticVar>,
 }
 
 impl CtxCliVar {

--- a/py_rust/src/config/schema.json
+++ b/py_rust/src/config/schema.json
@@ -92,21 +92,7 @@
                 "static": {
                     "description": "Statically configured global variables.",
                     "patternProperties": {
-                        "^.*$": {
-                            "type": "object",
-                            "properties": {
-                                "value": {
-                                    "description": "The value of the variable. Can be any valid toml value."
-                                },
-                                "coerce": {
-                                    "type": "string",
-                                    "description": "The type to coerce the value to. If not specified, the value kept as defined in the toml.",
-                                    "enum": ["json", "str", "int", "float", "bool"]
-                                }
-                            },
-                            "required": ["value"],
-                            "additionalProperties": false
-                        }
+                        "^.*$": { "$ref": "#/$defs/static_value" }
                     },
                     "additionalProperties": false
                 },
@@ -121,7 +107,8 @@
                                     "description": "The name of the environment variable to load into this context var, this defaults to the name of the config var."
                                 },
                                 "default": {
-                                    "description": "The default value of the variable if the environment variable is not set."
+                                    "description": "The default value of the variable if the environment variable is not set.",
+                                    "$ref": "#/$defs/static_value"
                                 },
                                 "coerce": {
                                     "type": "string",
@@ -149,7 +136,8 @@
                                     "minItems": 1
                                 },
                                 "light": {
-                                    "description": "The value to use when in rendering in --light or --superlight mode. If not set, the var will be treated as an empty string."
+                                    "description": "The value to use when in rendering in --light or --superlight mode. If not set, the var will be treated as an empty string.",
+                                    "$ref": "#/$defs/static_value"
                                 },
                                 "coerce": {
                                     "type": "string",
@@ -182,6 +170,21 @@
                     "minItems": 1
                 }
             },
+            "additionalProperties": false
+        },
+        "static_value": {
+            "type": "object",
+            "properties": {
+                "value": {
+                    "description": "The value of the variable. Can be any valid toml value."
+                },
+                "coerce": {
+                    "type": "string",
+                    "description": "The type to coerce the value to. If not specified, the value kept as defined in the toml.",
+                    "enum": ["json", "str", "int", "float", "bool"]
+                }
+            },
+            "required": ["value"],
             "additionalProperties": false
         }
     }

--- a/py_rust/src/config/validate.rs
+++ b/py_rust/src/config/validate.rs
@@ -61,17 +61,6 @@ pub fn post_validate(conf: &mut Config, config_path: &Path) -> Result<(), Zerr> 
         }
     }
 
-    // Check stat.value is not empty string, plus same for env.default (if provided):
-    for (key, value) in conf.context.stat.iter() {
-        validate_not_empty_string(format!("[context.static.{}.value]", key), &value.value)?;
-    }
-
-    for (key, value) in conf.context.env.iter() {
-        if let Some(default) = &value.default {
-            validate_not_empty_string(format!("[context.env.{}.default]", key), default)?;
-        }
-    }
-
     // ignore_files and engine.custom_extensions should be resolved relative to the config file, so rewrite the paths if needed and make sure they exist:
     let validate_and_rewrite = |in_path: String| -> Result<String, Zerr> {
         // Make relative to config file if not absolute:
@@ -224,20 +213,4 @@ fn run_against_schema(
         .compile_and_return(json_schema, true)
         .change_context(Zerr::InternalError)?;
     Ok(schema.validate(json))
-}
-
-fn validate_not_empty_string(context: String, value: &serde_json::Value) -> Result<(), Zerr> {
-    let valid = match &value {
-        serde_json::Value::String(s) => !s.trim().is_empty(),
-        _ => true,
-    };
-    if valid {
-        Ok(())
-    } else {
-        Err(zerr!(
-            Zerr::ConfigInvalid,
-            "{}: Cannot be an empty string.",
-            context
-        ))
-    }
 }

--- a/py_rust/src/init.rs
+++ b/py_rust/src/init.rs
@@ -95,7 +95,7 @@ custom_extensions = []
 FOO = {{ value = "foo" }}
 
 [context.env]
-BAR = {{ default = "bar" }}
+BAR = {{ default = {{ value = "bar" }} }}
 
 [context.cli]
 BAZ = {{ commands = ["echo 1"], coerce = "int" }}

--- a/py_rust/src/render/mod.rs
+++ b/py_rust/src/render/mod.rs
@@ -23,8 +23,6 @@ pub fn render(args: &crate::args::Args, render_args: &RenderCommand) -> Result<b
         self::lockfile::Lockfile::load(render_args.root.clone(), render_args.force)
     });
 
-    // TODO double prints what's that about
-
     let mut state = State::new(args)?;
     state.load_all_vars()?;
     debug!("State: {:#?}", state);

--- a/py_rust/src/state/active_state.rs
+++ b/py_rust/src/state/active_state.rs
@@ -115,7 +115,7 @@ impl State {
                 // In light mode use the user provided default or an empty string, rather than running a user command:
                 if self.light {
                     if let Some(light_val) = &value.light {
-                        Ok(light_val.clone())
+                        Ok(light_val.read()?)
                     } else {
                         Ok(serde_json::Value::String("".to_string()))
                     }
@@ -246,7 +246,7 @@ impl State {
                     // If light mode, need to use the light user replacement otherwise an empty string: (no need for threads)
                     if self.light {
                         let value = if let Some(light_val) = &var.light {
-                            light_val.clone()
+                            light_val.read()?
                         } else {
                             serde_json::Value::String("".to_string())
                         };

--- a/py_rust/tests/helpers/types.py
+++ b/py_rust/tests/helpers/types.py
@@ -6,12 +6,12 @@ Coerce_T = tp.Literal["str", "int", "float", "bool", "json"]
 class CliCtx(tp.TypedDict):
     commands: "list[str]"
     coerce: tp.NotRequired[Coerce_T]
-    light: tp.NotRequired[tp.Any]
+    light: tp.NotRequired["StaticCtx"]
 
 
 class EnvCtx(tp.TypedDict):
     env_name: tp.NotRequired[str]
-    default: tp.NotRequired[tp.Any]
+    default: tp.NotRequired["StaticCtx"]
     coerce: tp.NotRequired[Coerce_T]
 
 

--- a/py_rust/tests/render/test_ban_defaults.py
+++ b/py_rust/tests/render/test_ban_defaults.py
@@ -85,8 +85,8 @@ def test_ban_defaults(
                         {
                             "context": {
                                 "env": {
-                                    "TEST_RAND_1": {"default": "Hello"},
-                                    "TEST_RAND_2": {"default": "World"},
+                                    "TEST_RAND_1": {"default": {"value": "Hello"}},
+                                    "TEST_RAND_2": {"default": {"value": "World"}},
                                 }
                             }
                         }

--- a/py_rust/tests/render/test_custom_extensions.py
+++ b/py_rust/tests/render/test_custom_extensions.py
@@ -437,7 +437,7 @@ def capitalize(s):
                         "cli": {
                             "var_with_light": {
                                 "commands": ["echo bar"],
-                                "light": "init",
+                                "light": {"value": "init"},
                             }
                         }
                     },

--- a/py_rust/tests/render/test_extra_builtins.py
+++ b/py_rust/tests/render/test_extra_builtins.py
@@ -180,12 +180,12 @@ ENGINE_BUILTINS: AllBuiltins = {
     "functions": {
         # Custom to zetch:
         "env_default": {
-            "description": "Load the default context env var, rather than the active one. \n\nE.g. if you have context.env.FOO = { default = 'bar' } and the env variable is set to 'baz':\n\n{{ env_default('FOO') }} -> 'bar'\n{{ FOO }} -> 'baz'.",
+            "description": "Load the default context env var, rather than the active one. \n\nE.g. if you have context.env.FOO = { default = { value = 'bar' } } and the env variable is set to 'baz':\n\n{{ env_default('FOO') }} -> 'bar'\n{{ FOO }} -> 'baz'.",
             "tests": [
                 lambda: {
                     "input": "default: {{ env_default('FOO') }}, actual: {{ FOO }}",
                     "env": {"FOO": "baz"},
-                    "env_ctx": {"FOO": {"default": "bar"}},
+                    "env_ctx": {"FOO": {"default": {"value": "bar"}}},
                     "expected": "default: bar, actual: baz",
                 }
             ],

--- a/py_rust/tests/render/test_light_superlight.py
+++ b/py_rust/tests/render/test_light_superlight.py
@@ -22,7 +22,7 @@ from ..helpers.types import InputConfig
         ({"context": {"cli": {"VAR": {"commands": ["echo foo"]}}}}, "var: {{ VAR }}", "var: "),
         # Light value should work:
         (
-            {"context": {"cli": {"VAR": {"commands": ["echo foo"], "light": "LIGHT"}}}},
+            {"context": {"cli": {"VAR": {"commands": ["echo foo"], "light": {"value": "LIGHT"}}}}},
             "var: {{ VAR }}",
             "var: LIGHT",
         ),
@@ -31,11 +31,11 @@ from ..helpers.types import InputConfig
             {
                 "context": {
                     "static": {"VAR_STATIC": {"value": "STATIC"}},
-                    "env": {"VAR_ENV": {"default": "ENV"}},
+                    "env": {"VAR_ENV": {"default": {"value": "ENV"}}},
                     "cli": {
                         "VAR": {
                             "commands": ["echo foo"],
-                            "light": "LIGHT",
+                            "light": {"value": "LIGHT"},
                         }
                     },
                 }
@@ -165,7 +165,7 @@ def test_light_fixes_circular_dep():
                                     ),
                                 )
                             ],
-                            "light": "LIGHT",
+                            "light": {"value": "LIGHT"},
                         },
                     }
                 }

--- a/py_rust/tests/test_config_invalid.py
+++ b/py_rust/tests/test_config_invalid.py
@@ -86,22 +86,6 @@ def test_incorrect_config():
                     ),
                 )
 
-        # 'value' is empty string/null for static / env 'default':
-        for ctx_type, key_name in [("static", "value"), ("env", "default")]:
-            with pytest.raises(
-                ValueError,
-                match=re.escape(
-                    "[context.{}.FOO.{}]: Cannot be an empty string.".format(ctx_type, key_name)
-                ),
-            ):
-                cli.render(
-                    manager.root_dir,
-                    manager.tmpfile(
-                        "[context]\n[context.{}]\nFOO = {{ {} = '' }}\n".format(ctx_type, key_name),
-                        suffix=".toml",
-                    ),
-                )
-
         # Unknown key for static/env/cli:
         for ctx_key in ["static", "env", "cli"]:
             with pytest.raises(

--- a/py_rust/tests/test_var.py
+++ b/py_rust/tests/test_var.py
@@ -12,7 +12,7 @@ sample_config = """
   STAT_TEST_VAR = { value = ["Hello", "World"] }
 
 [context.env]
-  ENV_TEST_VAR = { default = "World" }
+  ENV_TEST_VAR = { default = { value = "World" } }
 
 [context.cli]
   CLI_TEST_VAR = { commands = ["echo 1"], coerce = "int" }


### PR DESCRIPTION
- **Improved render error to make part of line causing error bright red / underlined if known**
- **env defaults and cli lights use static syntax to allow coercion**
