### PR TITLE
Mix of previous behaviour and last update: static vars cli light values and defaults can all either use the shorthand of the full {value

### DIFF
--- a/py_rust/src/config/context.rs
+++ b/py_rust/src/config/context.rs
@@ -3,22 +3,11 @@ use std::{collections::HashMap, path::Path};
 use bitbazaar::cli::{Bash, BashErr};
 use serde::{Deserialize, Serialize};
 
+use super::static_var::CtxStaticVar;
 use crate::{
     coerce::{coerce, Coerce},
     prelude::*,
 };
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct CtxStaticVar {
-    pub value: serde_json::Value,
-    pub coerce: Option<Coerce>,
-}
-
-impl CtxStaticVar {
-    pub fn read(&self) -> Result<serde_json::Value, Zerr> {
-        coerce(&self.value, &self.coerce)
-    }
-}
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct CtxEnvVar {

--- a/py_rust/src/config/mod.rs
+++ b/py_rust/src/config/mod.rs
@@ -1,5 +1,6 @@
 pub mod conf;
 pub mod context;
 pub mod engine;
+mod static_var;
 pub mod tasks;
 mod validate;

--- a/py_rust/src/config/schema.json
+++ b/py_rust/src/config/schema.json
@@ -173,19 +173,32 @@
             "additionalProperties": false
         },
         "static_value": {
-            "type": "object",
-            "properties": {
-                "value": {
-                    "description": "The value of the variable. Can be any valid toml value."
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "value": {
+                            "description": "The value of the variable. Can be any valid toml value."
+                        },
+                        "coerce": {
+                            "type": "string",
+                            "description": "The type to coerce the value to. If not specified, the value kept as defined in the toml.",
+                            "enum": ["json", "str", "int", "float", "bool"]
+                        }
+                    },
+                    "required": ["value"],
+                    "additionalProperties": false
                 },
-                "coerce": {
-                    "type": "string",
-                    "description": "The type to coerce the value to. If not specified, the value kept as defined in the toml.",
-                    "enum": ["json", "str", "int", "float", "bool"]
+                {
+                    "description": "The value itself. Shorthand for { value = '..' }",
+                    "not": {
+                        "type": "object",
+                        "properties": { "coerce": {}, "value": {} },
+                        "required": ["value"],
+                        "additionalProperties": false
+                    }
                 }
-            },
-            "required": ["value"],
-            "additionalProperties": false
+            ]
         }
     }
 }

--- a/py_rust/src/config/static_var.rs
+++ b/py_rust/src/config/static_var.rs
@@ -1,0 +1,50 @@
+use serde::{Deserialize, Deserializer, Serialize};
+
+use crate::{
+    coerce::{coerce, Coerce},
+    prelude::*,
+};
+
+#[derive(Clone, Debug, Serialize)]
+pub struct CtxStaticVar {
+    pub value: serde_json::Value,
+    pub coerce: Option<Coerce>,
+}
+
+impl CtxStaticVar {
+    pub fn read(&self) -> Result<serde_json::Value, Zerr> {
+        coerce(&self.value, &self.coerce)
+    }
+}
+
+impl<'de> Deserialize<'de> for CtxStaticVar {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // Deserialize into a serde_json::Value first
+        let mut value: serde_json::Value = Deserialize::deserialize(deserializer)?;
+
+        // If an object, contains the value key, maybe the coerce key, and no other keys, treat as fully specified structure:
+        if matches!(&value, serde_json::Value::Object(map) if map.contains_key("value")
+        && (map.len() == 1 || (map.len() == 2 && map.contains_key("coerce"))))
+        {
+            let map = value.as_object_mut().unwrap();
+            Ok(CtxStaticVar {
+                value: map.remove("value").unwrap(),
+                // Coerce may or may not be present:
+                coerce: if let Some(coerce) = map.remove("coerce") {
+                    Some(Coerce::deserialize(coerce).map_err(serde::de::Error::custom)?)
+                } else {
+                    None
+                },
+            })
+        } else {
+            // Otherwise, treat the user entered as the "value", with no coerce:
+            Ok(CtxStaticVar {
+                value,
+                coerce: None,
+            })
+        }
+    }
+}

--- a/py_rust/tests/helpers/types.py
+++ b/py_rust/tests/helpers/types.py
@@ -2,16 +2,18 @@ import typing_extensions as tp
 
 Coerce_T = tp.Literal["str", "int", "float", "bool", "json"]
 
+StaticCtx_T: tp.TypeAlias = "StaticCtx | tp.Any"
+
 
 class CliCtx(tp.TypedDict):
     commands: "list[str]"
     coerce: tp.NotRequired[Coerce_T]
-    light: tp.NotRequired["StaticCtx"]
+    light: tp.NotRequired["StaticCtx_T"]
 
 
 class EnvCtx(tp.TypedDict):
     env_name: tp.NotRequired[str]
-    default: tp.NotRequired["StaticCtx"]
+    default: tp.NotRequired["StaticCtx_T"]
     coerce: tp.NotRequired[Coerce_T]
 
 
@@ -31,7 +33,7 @@ class Engine(tp.TypedDict):
 
 
 class InputContext(tp.TypedDict):
-    static: tp.NotRequired["dict[str, StaticCtx]"]
+    static: tp.NotRequired["dict[str, StaticCtx_T]"]
     cli: tp.NotRequired["dict[str, CliCtx]"]
     env: tp.NotRequired["dict[str, EnvCtx]"]
 

--- a/py_rust/tests/test_config_invalid.py
+++ b/py_rust/tests/test_config_invalid.py
@@ -28,6 +28,7 @@ def test_incorrect_config():
                 ),
             )
 
+        # TODO for light and env default too
         # Unknown coerce type for any ctx type:
         for ctx_type, extra_args in [
             ("static", {"value": "1"}),
@@ -53,8 +54,8 @@ def test_incorrect_config():
                     ),
                 )
 
-        # None dict format for any ctx type:
-        for ctx_type in ["static", "env", "cli"]:
+        # None dict format for env/cli types:
+        for ctx_type in ["env", "cli"]:
             with pytest.raises(
                 ValueError,
                 match=re.escape("[context.{}.FOO]: Expected a table.".format(ctx_type)),
@@ -67,27 +68,26 @@ def test_incorrect_config():
                     ),
                 )
 
-        # Missing 'value' for static ctx or 'commands' for cli:
-        for ctx_type, key_name in [("static", "value"), ("cli", "commands")]:
-            with pytest.raises(
-                ValueError,
-                match=re.escape(
-                    "[context.{}.FOO.{}]: This property is required.".format(
-                        ctx_type,
-                        key_name,
-                    )
-                ),
-            ):
-                cli.render(
-                    manager.root_dir,
-                    manager.tmpfile(
-                        "[context]\n[context.{}]\nFOO = {{}}\n".format(ctx_type),
-                        suffix=".toml",
-                    ),
+        # Missing 'commands' for cli:
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "[context.{}.FOO.{}]: This property is required.".format(
+                    ctx_type,
+                    "commands",
                 )
+            ),
+        ):
+            cli.render(
+                manager.root_dir,
+                manager.tmpfile(
+                    "[context]\n[context.cli]\nFOO = {}\n",
+                    suffix=".toml",
+                ),
+            )
 
-        # Unknown key for static/env/cli:
-        for ctx_key in ["static", "env", "cli"]:
+        # Unknown key for env/cli:
+        for ctx_key in ["env", "cli"]:
             with pytest.raises(
                 ValueError,
                 match=re.escape("[context.{}.FOO]: Unknown property: 'bar'.".format(ctx_key)),

--- a/py_rust/tests/test_config_valid.py
+++ b/py_rust/tests/test_config_valid.py
@@ -28,6 +28,25 @@ def cfg_str(config: InputConfig) -> str:
                         "cli": {
                             "FOO": {
                                 "commands": ['echo "Hello, World!"'],
+                                "light": "LIGHT",
+                            }
+                        }
+                    }
+                }
+            ),
+            {"FOO": "Hello, World!"},
+        ),
+        # Light shorthand:
+        (
+            {},
+            "ctx",
+            cfg_str(
+                {
+                    "context": {
+                        "cli": {
+                            "FOO": {
+                                "commands": ['echo "Hello, World!"'],
+                                "light": "LIGHT",
                             }
                         }
                     }
@@ -54,10 +73,18 @@ def cfg_str(config: InputConfig) -> str:
             ),
             {"FOO": "Hello, World!"},
         ),
+        # Static:
         (
             {},
             "ctx",
             cfg_str({"context": {"static": {"FOO": {"value": "Hello, World!"}}}}),
+            {"FOO": "Hello, World!"},
+        ),
+        # Static shorthand:
+        (
+            {},
+            "ctx",
+            cfg_str({"context": {"static": {"FOO": "Hello, World!"}}}),
             {"FOO": "Hello, World!"},
         ),
         (
@@ -77,6 +104,13 @@ def cfg_str(config: InputConfig) -> str:
             {"FOO": "abc"},
             "ctx",
             cfg_str({"context": {"env": {"FOO": {"default": {"value": True}}}}}),
+            {"FOO": "abc"},
+        ),
+        # Env default shorthand:
+        (
+            {"FOO": "abc"},
+            "ctx",
+            cfg_str({"context": {"env": {"FOO": {"default": True}}}}),
             {"FOO": "abc"},
         ),
         # Should only use default when no env var:
@@ -287,101 +321,74 @@ def test_parallelized_context_cli_commands():
 def test_valid_coercion(as_type: tp.Any, input_val: tp.Any, expected: tp.Any):
     """Confirm value conversion works correctly when valid in all input types."""
     with TmpFileManager() as manager:
-        # Check:
-        # - Static
-        # - CLI
-        # - Env
-        # - Cli light values
-        # - Env default values
 
-        assert (
-            cli.render(
-                manager.root_dir,
-                manager.create_cfg(
-                    {"context": {"static": {"FOO": {"value": input_val, "coerce": as_type}}}}
-                ),
-            )["debug"]["ctx"]["FOO"]
-            == expected
-        )
+        def check(cfg: InputConfig, extra_args: tp.Optional["list[str]"] = None):
+            assert (
+                cli.render(
+                    manager.root_dir,
+                    manager.create_cfg(cfg),
+                    extra_args=extra_args,
+                )["debug"]["ctx"]["FOO"]
+                == expected
+            )
 
+        # Static:
+        check({"context": {"static": {"FOO": {"value": input_val, "coerce": as_type}}}})
+
+        # Cli:
         tmpfile = manager.tmpfile(str(input_val), suffix=".txt")
-        assert (
-            cli.render(
-                manager.root_dir,
-                manager.create_cfg(
-                    {
-                        "context": {
-                            "cli": {
-                                "FOO": {
-                                    "commands": [
-                                        '{} "{}"'.format(
-                                            utils.cat_cmd_cross(),
-                                            utils.str_path_for_tmpl_writing(tmpfile),
-                                        )
-                                    ],
-                                    "coerce": as_type,
-                                }
-                            }
+        check(
+            {
+                "context": {
+                    "cli": {
+                        "FOO": {
+                            "commands": [
+                                '{} "{}"'.format(
+                                    utils.cat_cmd_cross(),
+                                    utils.str_path_for_tmpl_writing(tmpfile),
+                                )
+                            ],
+                            "coerce": as_type,
                         }
                     }
-                ),
-            )["debug"]["ctx"]["FOO"]
-            == expected
+                }
+            }
         )
 
+        # Env using real value:
         with mock.patch.dict(
             os.environ,
             {
                 "FOO": str(input_val),
             },
         ):
-            assert (
-                cli.render(
-                    manager.root_dir,
-                    manager.create_cfg(
-                        {"context": {"env": {"FOO": {"env_name": "FOO", "coerce": as_type}}}},
-                    ),
-                )["debug"]["ctx"]["FOO"]
-                == expected
-            )
+            check({"context": {"env": {"FOO": {"env_name": "FOO", "coerce": as_type}}}})
 
         # Cli light values:
-        assert (
-            cli.render(
-                manager.root_dir,
-                manager.create_cfg(
-                    {
-                        "context": {
-                            "cli": {
-                                "FOO": {
-                                    "commands": ["echo bar"],
-                                    "light": {"value": input_val, "coerce": as_type},
-                                }
-                            }
+        check(
+            {
+                "context": {
+                    "cli": {
+                        "FOO": {
+                            "commands": ["echo bar"],
+                            "light": {"value": input_val, "coerce": as_type},
                         }
-                    },
-                ),
-                extra_args=["--light"],
-            )["debug"]["ctx"]["FOO"]
-            == expected
+                    }
+                }
+            },
+            extra_args=["--light"],
         )
 
         # Env default values:
-        assert (
-            cli.render(
-                manager.root_dir,
-                manager.create_cfg(
-                    {
-                        "context": {
-                            "env": {
-                                "FOO": {
-                                    "env_name": "FOO",
-                                    "default": {"value": input_val, "coerce": as_type},
-                                }
-                            }
+        check(
+            {
+                "context": {
+                    "env": {
+                        "FOO": {
+                            "env_name": "FOO",
+                            "default": {"value": input_val, "coerce": as_type},
                         }
                     }
-                ),
-            )["debug"]["ctx"]["FOO"]
-            == expected
+                }
+            }
         )


### PR DESCRIPTION
 coerce} syntax, reduces the bloat in the config file significantly,